### PR TITLE
update to retread v4.1 pack schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ Here is where to put the entrypoints your user may care about.
 ### Adding a dependency to a retread pack (incremental)
 
 The `*-pack*/` directories are [pixi-build-retread](https://github.com/garylvov/pixi-build-retread)
-packs (backend pinned `>=2.10.0`). Each has a committed `retread-*.lock.json` capturing its
-resolved closure.
+packs (backend pinned `>=4.1.0` from [prefix.dev/garylvov](https://prefix.dev/garylvov)). Each has
+a committed `retread-*.lock.json` capturing its resolved closure. The uv closure engine is the
+default (spelled out as `retread-resolver = "uv"` in each pack; set `"legacy"` to fall back).
 
 To add a dependency to a pack, add it under `[package.build.config.retread-wheels]` in the
 pack's `pixi.toml`, then install with `RETREAD_INCREMENTAL=1`:
@@ -166,6 +167,26 @@ since retread `>=2.10.0`, full resolves **favor the committed lock's versions** 
 (disable with `RETREAD_NO_FAVOR_LOCK=1`), so even a cold re-resolve keeps unrelated versions
 stable. Optionally set `RETREAD_VERIFY_LOCALADD=1` to log an internal-consistency check of the
 resulting closure.
+
+### Retread fast path (shared filesystems / clusters)
+
+On machines where the project and caches live on slow shared storage (SLURM clusters,
+EC2 + EFS), retread can reroute caches and env storage to fast machine-local disk:
+
+```bash
+# Activate the fast path (reroutes caches/envs to local disk; auto-disengages
+# on machines that already have fast local storage):
+eval "$(pixi-build-retread fast --print-env)"
+
+pixi install -e isaaclab-gpu   # materializes from the envs-persist snapshot
+                               # (lock-hash match) or a no-resolve frozen rebuild
+
+# After changing an env, refresh its snapshot:
+pixi-build-retread fast --persist isaaclab-gpu
+```
+
+Reactivation on a warm node is resolve-free: with a matching lock hash the env is
+restored by parallel copy from the persisted snapshot instead of re-solving.
 
 ## Community Contributions
 

--- a/genesis-pack/pixi.toml
+++ b/genesis-pack/pixi.toml
@@ -6,7 +6,7 @@ name = "genesis-pack"
 version = "1.1.1"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }
@@ -18,6 +18,9 @@ backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 0
 retread-python = "3.12"
+# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
+# Fall back with retread-resolver = "legacy" if needed.
+retread-resolver = "uv"
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `genesis-pack`.
 retread-bundle = "genesis-pack"

--- a/isaac-pack-latest/pixi.toml
+++ b/isaac-pack-latest/pixi.toml
@@ -6,7 +6,7 @@ name = "isaac-pack-latest"
 version = "6.0.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }
@@ -18,6 +18,9 @@ backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 0
 retread-python = "3.12"
+# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
+# Fall back with retread-resolver = "legacy" if needed.
+retread-resolver = "uv"
 retread-compression-level = 1
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `isaac-pack-latest`.

--- a/isaac-pack/pixi.toml
+++ b/isaac-pack/pixi.toml
@@ -6,7 +6,7 @@ name = "isaac-pack"
 version = "6.0.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }
@@ -18,6 +18,9 @@ backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 2
 retread-python = "3.12"
+# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
+# Fall back with retread-resolver = "legacy" if needed.
+retread-resolver = "uv"
 retread-compression-level = 1
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `isaac-pack`.

--- a/newton-pack-latest/pixi.toml
+++ b/newton-pack-latest/pixi.toml
@@ -6,7 +6,7 @@ name = "newton-pack-latest"
 version = "1.3.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }
@@ -18,6 +18,9 @@ backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 0
 retread-python = "3.12"
+# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
+# Fall back with retread-resolver = "legacy" if needed.
+retread-resolver = "uv"
 retread-compression-level = 1
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `newton-pack-latest`.

--- a/pixi.toml
+++ b/pixi.toml
@@ -87,6 +87,10 @@ CUDA_HOME = "$CONDA_PREFIX"
 # Thank you to Matthew Feickert for the system requirements tip!
 # https://pixi.sh/latest/workspace/system_requirements/
 # https://matthewfeickert-talks.github.io/reproducible-ml-for-scientists-with-pixi-scipy-2025/cuda-conda
+# NOTE: this legacy [system-requirements] table works on pixi 0.70-0.72
+# (0.71+ only warns that it is deprecated). The pixi 0.71+ rich `platforms`
+# form is also supported by retread >=4.1.0, e.g. in [workspace]:
+#   platforms = [{ platform = "linux-64", glibc = "2.35", cuda = "12" }]
 cuda   = "12"
 [feature.gpu.dependencies]
 # Keep the torch family on conda. conda-forge's PyTorch 2.10 GPU builds require CUDA 12.9.
@@ -222,6 +226,8 @@ ipywidgets = "==8.1.5"
 [feature.isaaclab.target.unix.activation]
 scripts = ["scripts/config-isaacsim.bash"]
 [feature.isaaclab.system-requirements]
+# Legacy form (works on pixi 0.70-0.72); the 0.71+ rich `platforms` form is
+# also supported -- see the note on [feature.gpu.system-requirements].
 libc = "2.35"
 
 ### Isaac Lab Latest Environment-----------------------------------------------------------------
@@ -241,6 +247,8 @@ ipywidgets = "==8.1.5"
 [feature.isaaclab-latest.target.unix.activation]
 scripts = ["scripts/config-isaacsim.bash"]
 [feature.isaaclab-latest.system-requirements]
+# Legacy form (works on pixi 0.70-0.72); the 0.71+ rich `platforms` form is
+# also supported -- see the note on [feature.gpu.system-requirements].
 libc = "2.35"
 
 ### Newton Environment---------------------------------------------------------------------------


### PR DESCRIPTION
- backend pin `>=2.10.0` -> `>=4.1.0` (channel https://prefix.dev/garylvov)
- spell out `retread-resolver = "uv"` (default closure engine since v4.0.0)
- system-requirements: legacy form kept (works pixi 0.70-0.72) with a comment noting the 0.71+ rich `platforms` form is also supported
- README: retread fast path (`fast --print-env`, `fast --persist`, no-resolve reactivation)

Sanity: `pixi info` parses on pixi 0.70.2; no installs performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)