### PR TITLE
Fix CI: pixi >=0.70 for retread v4.1 packs, legacy resolver for isaac packs

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -20,10 +20,16 @@ jobs:
           export PIXI_PROJECT_ROOT=$(pwd)
           bash scripts/get_submodules_and_patches.bash
 
+      # Retread packs (isaac-pack, etc.) require pixi >=0.70 for the v4.1 pack
+      # schema. Only the cheap `test` (cpu) environment is installed here: the
+      # GPU / isaac environments pull wheel closures that are tens of GB and
+      # would blow past GitHub runner disk and time limits.
       - name: Install Pixi
-        uses: prefix-dev/setup-pixi@v0.8.8
+        uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.69.0
+          pixi-version: v0.70.2
+          environments: test
+          locked: true
 
       - name: Run lint
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,10 +20,16 @@ jobs:
           export PIXI_PROJECT_ROOT=$(pwd)
           bash scripts/get_submodules_and_patches.bash
 
+      # Retread packs (isaac-pack, etc.) require pixi >=0.70 for the v4.1 pack
+      # schema. Only the cheap `test` (cpu) environment is installed here: the
+      # GPU / isaac environments pull wheel closures that are tens of GB and
+      # would blow past GitHub runner disk and time limits.
       - name: Install Pixi
-        uses: prefix-dev/setup-pixi@v0.8.8
+        uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          pixi-version: v0.69.0
+          pixi-version: v0.70.2
+          environments: test
+          locked: true
 
       - name : Run test
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ isaac-pack/retread-pypi/
 # retread progress logs (build/install phase markers)
 *-pack*/retread-progress-*.log
 retread-progress-*.log
+
+# retread solve ledgers (local scratch state from `pixi-build-retread solve`)
+*-pack*/.retread/

--- a/isaac-pack-latest/pixi.toml
+++ b/isaac-pack-latest/pixi.toml
@@ -18,9 +18,10 @@ backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 0
 retread-python = "3.12"
-# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
-# Fall back with retread-resolver = "legacy" if needed.
-retread-resolver = "uv"
+# uv is the default closure engine (v4.0.0+), but it rejects this closure's
+# pinned prerelease deps (isaacsim-core -> tinyobjloader==2.0.0rc13) and does
+# not consume the committed lock's prerelease pins, so use the legacy engine.
+retread-resolver = "legacy"
 retread-compression-level = 1
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `isaac-pack-latest`.

--- a/isaac-pack/pixi.toml
+++ b/isaac-pack/pixi.toml
@@ -18,9 +18,10 @@ backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 2
 retread-python = "3.12"
-# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
-# Fall back with retread-resolver = "legacy" if needed.
-retread-resolver = "uv"
+# uv is the default closure engine (v4.0.0+), but it rejects this closure's
+# pinned prerelease deps (isaacsim-core -> tinyobjloader==2.0.0rc13) and does
+# not consume the committed lock's prerelease pins, so use the legacy engine.
+retread-resolver = "legacy"
 retread-compression-level = 1
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `isaac-pack`.


### PR DESCRIPTION
CI has failed on main since 6cad470 (retread v4.1 pack schema): setup-pixi runs `pixi install --locked` and gets `lock-file not up-to-date with the workspace`. Regenerating the lock exposed the underlying issue: retread 4.1.0's uv closure engine rejects the isaac packs' pinned prerelease deps (`isaacsim-core -> tinyobjloader==2.0.0rc13`) and does not consume the committed retread lock's `prerelease` pins, so any cold re-solve of `isaac-pack` / `isaac-pack-latest` fails (worth reporting upstream to pixi-build-retread).

- `isaac-pack`, `isaac-pack-latest`: `retread-resolver = "uv"` -> `"legacy"` (the documented fallback). `pixi-build-retread solve` converges and `pixi lock --check` passes with pixi 0.70.2. genesis-pack / newton-pack-latest have no prerelease pins and stay on uv.
- Workflows: setup-pixi v0.8.8 -> v0.10.0, pixi v0.69.0 -> v0.70.2 (v4.1 pack schema needs >=0.70); install only the cheap cpu `test` environment with `locked: true` -- the isaac/GPU wheel closures are tens of GB and must never be fully installed on GitHub runners (comment added in both workflows).
- `.gitignore`: exclude `*-pack*/.retread/` solve ledgers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)