### PR TITLE
packs: require retread backend >=4.3.0

### DIFF
--- a/genesis-pack/pixi.toml
+++ b/genesis-pack/pixi.toml
@@ -6,7 +6,7 @@ name = "genesis-pack"
 version = "1.1.1"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.3.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }

--- a/isaac-pack-latest/pixi.toml
+++ b/isaac-pack-latest/pixi.toml
@@ -6,7 +6,7 @@ name = "isaac-pack-latest"
 version = "6.0.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.3.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }

--- a/isaac-pack/pixi.toml
+++ b/isaac-pack/pixi.toml
@@ -6,7 +6,7 @@ name = "isaac-pack"
 version = "6.0.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.3.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }

--- a/newton-pack-latest/pixi.toml
+++ b/newton-pack-latest/pixi.toml
@@ -6,7 +6,7 @@ name = "newton-pack-latest"
 version = "1.3.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=4.1.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.3.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }


### PR DESCRIPTION
Bump pixi-build-retread backend pin from `>=4.1.0` to `>=4.3.0` in all 4 packs (genesis, isaac, isaac-pack-latest, newton-pack-latest) so they pull the newly published v4.3.0 backend from prefix.dev/garylvov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)