### PR TITLE
packs: retread v4.4.0 (courier-mode activation, drop insecure config)

### DIFF
--- a/.pixi/config.toml
+++ b/.pixi/config.toml
@@ -1,1 +1,0 @@
-run-post-link-scripts = "insecure"

--- a/README.md
+++ b/README.md
@@ -147,9 +147,13 @@ Here is where to put the entrypoints your user may care about.
 ### Adding a dependency to a retread pack (incremental)
 
 The `*-pack*/` directories are [pixi-build-retread](https://github.com/garylvov/pixi-build-retread)
-packs (backend pinned `>=4.1.0` from [prefix.dev/garylvov](https://prefix.dev/garylvov)). Each has
-a committed `retread-*.lock.json` capturing its resolved closure. The uv closure engine is the
-default (spelled out as `retread-resolver = "uv"` in each pack; set `"legacy"` to fall back).
+packs (backend pinned `>=4.4.0` from [prefix.dev/garylvov](https://prefix.dev/garylvov)). Each has
+a committed `retread-*.lock.json` capturing its resolved closure. uv is the only closure engine as
+of v4.4.0 (the legacy resolver was removed); the wheel closure is always computed by uv. Each pack
+sets `retread-courier-mode = "activation"`, so the bundled wheels install lazily on first `pixi
+run`/`shell` via the activate.d self-heal guard -- no conda post-link script and **no
+`run-post-link-scripts = "insecure"`** in `.pixi/config.toml`. Conda/PyPI conflicts auto-resolved
+during a solve persist as overrides in each pack's `.retread` ledger.
 
 To add a dependency to a pack, add it under `[package.build.config.retread-wheels]` in the
 pack's `pixi.toml`, then install with `RETREAD_INCREMENTAL=1`:

--- a/genesis-pack/pixi.toml
+++ b/genesis-pack/pixi.toml
@@ -6,21 +6,22 @@ name = "genesis-pack"
 version = "1.1.1"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=4.3.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.4.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }
 
 [package.build.config]
-# courier mode is the default (v2.1.0+); installs the bundled wheels via the
-# conda post-link script (requires run-post-link-scripts = "insecure" in the
-# consumer's .pixi/config.toml).
+# courier mode is the default (v2.1.0+). retread-courier-mode = "activation"
+# installs the bundled wheels lazily on first `pixi run`/`shell` via the
+# activate.d self-heal guard -- no conda post-link script, so no
+# `run-post-link-scripts = "insecure"` is needed in the consumer's .pixi/config.toml.
+retread-courier-mode = "activation"
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 0
 retread-python = "3.12"
-# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
-# Fall back with retread-resolver = "legacy" if needed.
-retread-resolver = "uv"
+# uv is the only closure engine as of v4.4.0 (the legacy resolver knob was
+# removed); the wheel closure is always computed by uv.
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `genesis-pack`.
 retread-bundle = "genesis-pack"

--- a/isaac-pack-latest/pixi.toml
+++ b/isaac-pack-latest/pixi.toml
@@ -6,21 +6,22 @@ name = "isaac-pack-latest"
 version = "6.0.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=4.3.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.4.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }
 
 [package.build.config]
-# courier mode is the default (v2.1.0+); installs the bundled wheels via the
-# conda post-link script (requires run-post-link-scripts = "insecure" in the
-# consumer's .pixi/config.toml).
+# courier mode is the default (v2.1.0+). retread-courier-mode = "activation"
+# installs the bundled wheels lazily on first `pixi run`/`shell` via the
+# activate.d self-heal guard -- no conda post-link script, so no
+# `run-post-link-scripts = "insecure"` is needed in the consumer's .pixi/config.toml.
+retread-courier-mode = "activation"
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 0
 retread-python = "3.12"
-# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
-# Fall back with retread-resolver = "legacy" if needed.
-retread-resolver = "uv"
+# uv is the only closure engine as of v4.4.0 (the legacy resolver knob was
+# removed); the wheel closure is always computed by uv.
 retread-compression-level = 1
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `isaac-pack-latest`.

--- a/isaac-pack/pixi.toml
+++ b/isaac-pack/pixi.toml
@@ -6,21 +6,22 @@ name = "isaac-pack"
 version = "6.0.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=4.3.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.4.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }
 
 [package.build.config]
-# courier mode is the default (v2.1.0+); installs the bundled wheels via the
-# conda post-link script (requires run-post-link-scripts = "insecure" in the
-# consumer's .pixi/config.toml).
+# courier mode is the default (v2.1.0+). retread-courier-mode = "activation"
+# installs the bundled wheels lazily on first `pixi run`/`shell` via the
+# activate.d self-heal guard -- no conda post-link script, so no
+# `run-post-link-scripts = "insecure"` is needed in the consumer's .pixi/config.toml.
+retread-courier-mode = "activation"
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 2
 retread-python = "3.12"
-# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
-# Fall back with retread-resolver = "legacy" if needed.
-retread-resolver = "uv"
+# uv is the only closure engine as of v4.4.0 (the legacy resolver knob was
+# removed); the wheel closure is always computed by uv.
 retread-compression-level = 1
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `isaac-pack`.

--- a/newton-pack-latest/pixi.toml
+++ b/newton-pack-latest/pixi.toml
@@ -6,21 +6,22 @@ name = "newton-pack-latest"
 version = "1.3.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=4.3.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=4.4.0", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }
 
 [package.build.config]
-# courier mode is the default (v2.1.0+); installs the bundled wheels via the
-# conda post-link script (requires run-post-link-scripts = "insecure" in the
-# consumer's .pixi/config.toml).
+# courier mode is the default (v2.1.0+). retread-courier-mode = "activation"
+# installs the bundled wheels lazily on first `pixi run`/`shell` via the
+# activate.d self-heal guard -- no conda post-link script, so no
+# `run-post-link-scripts = "insecure"` is needed in the consumer's .pixi/config.toml.
+retread-courier-mode = "activation"
 retread-relax = "patch-then-minor-then-major-then-last-resort"
 retread-build-number = 0
 retread-python = "3.12"
-# uv is the default closure engine (v4.0.0+); spelled out here for clarity.
-# Fall back with retread-resolver = "legacy" if needed.
-retread-resolver = "uv"
+# uv is the only closure engine as of v4.4.0 (the legacy resolver knob was
+# removed); the wheel closure is always computed by uv.
 retread-compression-level = 1
 # v1.4.0+ pack-wide default bundle group: collapses every entry below into one
 # conda output named `newton-pack-latest`.


### PR DESCRIPTION
Models the clean retread v4.4.0 path.

- Bump pack backend pins `>=4.3.0` -> `>=4.4.0` (published: `pixi-build-retread-4.4.0` on prefix.dev/garylvov).
- Set `retread-courier-mode = "activation"` in each pack: bundled wheels install lazily on first `pixi run`/`shell` via the activate.d self-heal guard, so no conda post-link script.
- Remove `run-post-link-scripts = "insecure"` from `.pixi/config.toml` (unnecessary in activation mode).
- Drop the deprecated `retread-resolver` knob (uv is the only resolver as of v4.4.0; legacy resolver removed backend-side).
- README refreshed: retread v4.4.0, `fast --print-env` cluster workflow, activation courier-mode = no insecure config, overrides persist in `.retread` ledger.

`pixi info` parses clean (pixi 0.70.2); `Config locations: No config files found` confirms the insecure config is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)