### PR TITLE
stepback: bump retread backend pin to >=3.0.3 + document 4.x vendored-wheel requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,14 @@ Here is where to put the entrypoints your user may care about.
 ### Adding a dependency to a retread pack (incremental)
 
 The `*-pack*/` directories are [pixi-build-retread](https://github.com/garylvov/pixi-build-retread)
-packs (backend pinned `>=2.10.0`). Each has a committed `retread-*.lock.json` capturing its
+packs (backend pinned `>=3.0.3`). Each has a committed `retread-*.lock.json` capturing its
 resolved closure.
+
+> **Backend 4.x note:** the published backend is now `4.x`. Its uv closure disables
+> build-from-source and pre-releases, so sdist-only or pre-release transitive deps of Isaac Sim
+> (e.g. `idna-ssl`, `tinyobjloader==2.0.0rc13`) must be supplied as direct-URL wheels under
+> `[package.build.config.retread-wheels]`, or built incrementally with `RETREAD_INCREMENTAL=1`
+> (reuses the committed lock's closure). See the imprint retread env fix for the pattern.
 
 To add a dependency to a pack, add it under `[package.build.config.retread-wheels]` in the
 pack's `pixi.toml`, then install with `RETREAD_INCREMENTAL=1`:

--- a/genesis-pack/pixi.toml
+++ b/genesis-pack/pixi.toml
@@ -6,7 +6,7 @@ name = "genesis-pack"
 version = "1.1.1"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=3.0.3", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }

--- a/isaac-pack-latest/pixi.toml
+++ b/isaac-pack-latest/pixi.toml
@@ -6,7 +6,7 @@ name = "isaac-pack-latest"
 version = "6.0.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=3.0.3", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }

--- a/isaac-pack/pixi.toml
+++ b/isaac-pack/pixi.toml
@@ -6,7 +6,7 @@ name = "isaac-pack"
 version = "6.0.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=3.0.3", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }

--- a/newton-pack-latest/pixi.toml
+++ b/newton-pack-latest/pixi.toml
@@ -6,7 +6,7 @@ name = "newton-pack-latest"
 version = "1.3.0"
 
 [package.build]
-backend = { name = "pixi-build-retread", version = ">=2.10.0", channels = [
+backend = { name = "pixi-build-retread", version = ">=3.0.3", channels = [
   "https://prefix.dev/garylvov",
   "https://prefix.dev/conda-forge",
 ] }


### PR DESCRIPTION
## Summary
Aligns pixidock_template's `pixi-build-retread` consumption with reality: the published backend is now **4.x** (the `prefix.dev/garylvov` channel serves 4.2.0–4.4.0), and the old `>=2.10.0` pin's 2.10.x is gone from the channel.

- Bump the 4 pack backend pins `>=2.10.0 → >=3.0.3` (resolves to 4.4.0), matching imprint.
- README note: backend 4.x's uv closure disables build-from-source and pre-releases, so sdist-only or pre-release transitive deps of Isaac Sim (e.g. `idna-ssl`, `tinyobjloader==2.0.0rc13`) must be supplied as direct-URL `retread-wheels` (or built incrementally with `RETREAD_INCREMENTAL=1`). See the companion imprint retread env fix for the pattern.

## Not touched (investigated)
- The 4 `wheels/` dirs are **gitignored local build caches**, not tracked duplicates (isaac-pack has `nvidia_srl_*`, isaac-pack-latest has `pytetwild` — different packs), so they are NOT deleted.
- `IsaacLabNewton/`, `patches/egl_probe/`, `ros2_ws/` are untracked and referenced nowhere; left as-is (they never enter a commit).